### PR TITLE
Fix exit code in test configurations

### DIFF
--- a/integration/exit.c
+++ b/integration/exit.c
@@ -1,4 +1,4 @@
-// { "exitCode": "1" }
+// { "exitCode": 1 }
 
 #include <assert.h>
 #include <stdlib.h>

--- a/integration/std_process_exit.rs
+++ b/integration/std_process_exit.rs
@@ -1,4 +1,4 @@
-// { "exitCode": "120" }
+// { "exitCode": 120 }
 
 fn main() {
   std::process::exit(120);


### PR DESCRIPTION
The exit code is represented as a string in the exit.c and std_process_exit.rs tests which is incorrect.

This replaces them with plain numbers so that no additional conversion is required when parsing the test configuration.