### PR TITLE
Fix incorrect command line arguments tests

### DIFF
--- a/integration/args.c
+++ b/integration/args.c
@@ -4,8 +4,9 @@
 #include <string.h>
 
 int main(int argc, char* argv[]) {
-	assert(argc == 3);
-	assert(strcmp(argv[0], "one") == 0);
-	assert(strcmp(argv[1], "two") == 0);
-	assert(strcmp(argv[2], "three") == 0);
+	assert(argc == 4);
+	assert(strstr(argv[0], "args.wasm") != NULL);
+	assert(strcmp(argv[1], "one") == 0);
+	assert(strcmp(argv[2], "two") == 0);
+	assert(strcmp(argv[3], "three") == 0);
 }

--- a/integration/std_env_args.rs
+++ b/integration/std_env_args.rs
@@ -2,7 +2,8 @@
 
 fn main() {
   let mut args = std::env::args();
-  assert_eq!(args.len(), 3);
+  assert_eq!(args.len(), 4);
+  assert!(args.next().unwrap().contains("std_env_args.wasm"));
   assert_eq!(args.next().unwrap(), "one");
   assert_eq!(args.next().unwrap(), "two");
   assert_eq!(args.next().unwrap(), "three");


### PR DESCRIPTION
The command line arguments tests incorretly assumes that there will be no implicit argv[0].

This corrects this incrementing the number of expected args by one and asserts that argv[0] contains at-least the basename of the test case.