### PR TITLE
Remove stale asserts import

### DIFF
--- a/compat.py
+++ b/compat.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import asserts
 import glob
 import json
 import os


### PR DESCRIPTION
Accidentally left behind an unused import of the third-party asserts module from pip.

This removes the offending import.