### PR TITLE
Use a recursive glob pattern to find tests

### DIFF
--- a/compat.py
+++ b/compat.py
@@ -167,7 +167,7 @@ def test_wasmtime(filepath, config):
 
 def main():
     inputs = []
-    inputs.extend(glob.glob("build/**/*.wasm"))
+    inputs.extend(glob.glob("**/*.wasm", recursive=True))
 
     tests = {
             "deno": test_deno,


### PR DESCRIPTION
This replaces the hardcoded build path with a recursive glob pattern for **/*.wasm which will pick up tests no matter where in the tree the output directory is located.

See also #10 which made the output directory configurable.