### PR TITLE
Only try to build files matching .c and *.rs

### DIFF
--- a/build.py
+++ b/build.py
@@ -62,7 +62,11 @@ def main():
 
     args = parser.parse_args()
 
-    for filepath in glob.iglob('integration/*.*'):
+    sources = []
+    sources.extend(glob.glob('integration/*.c'))
+    sources.extend(glob.glob('integration/*.rs'))
+
+    for filepath in sources:
         build_test(filepath, outdir=args.outdir)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Currently all files in the integration folder are being built which can cause problems when tests are built next to their source files.

This filters the source files so that only files matching integration/*.c and integration/*.rs patterns are considered.