### PR TITLE
Remove stale commented out debug print statement

### DIFF
--- a/compat.py
+++ b/compat.py
@@ -110,7 +110,6 @@ def test_node(filepath, config):
     cmd.append(json.dumps(config))
     cmd.append(filepath)
 
-    # print(' '.join(cmd))
     test(cmd, config)
 
 def test_wasmer(filepath, config):


### PR DESCRIPTION
There's a stale commented out debug print statement that accidentally slipped through.

This removes the offending comment.