### PR TITLE
Validate prelude is valid json during build step

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,7 @@ name = "wasi-test"
 version = "0.0.0"
 authors = ["Casper Beyer <caspervonb@pm.me>"]
 edition = "2018"
+
+[build-dependencies]
+serde = "1.0"
+serde_json = "1.0"

--- a/build.rs
+++ b/build.rs
@@ -13,6 +13,9 @@ fn generate_spec(src_dir: &std::path::Path, out_dir: &std::path::Path) {
                 .replace(".rs", ".json"),
                 );
 
+            let value: serde_json::Value = serde_json::from_str(&prelude).unwrap();
+            let prelude = value.to_string();
+
             let out_data = prelude.as_bytes();
 
             std::fs::write(out_path, out_data).unwrap();


### PR DESCRIPTION
This passes the prelude through serde when generating spec files to ensure that the prelude is in-fact a valid json before writing it out to disk.