### PR TITLE
Format json prelude

### DIFF
--- a/src/bin/std_env_args.rs
+++ b/src/bin/std_env_args.rs
@@ -1,4 +1,10 @@
-// { "args": ["one", "two", "three" ]}
+// {
+//     "args": [
+//         "one",
+//         "two",
+//         "three"
+//     ]
+// }
 
 fn main() {
   let mut args = std::env::args();

--- a/src/bin/std_env_vars.rs
+++ b/src/bin/std_env_vars.rs
@@ -1,4 +1,10 @@
-// { "env": { "one": "1", "two": "2", "three": "3" } }
+// {
+//     "env": {
+//         "one": "1",
+//         "two": "2",
+//         "three": "3"
+//     }
+// }
 
 fn main() {
   let vars = std::env::vars();

--- a/src/bin/std_fs_create_dir.rs
+++ b/src/bin/std_fs_create_dir.rs
@@ -1,4 +1,8 @@
-// { "preopens": { "/scratch": "scratch" } }
+// {
+//     "preopens": {
+//         "/scratch": "scratch"
+//     }
+// }
 
 fn main() {
   assert!(std::fs::create_dir("/scratch/directory").is_ok());

--- a/src/bin/std_fs_file_create.rs
+++ b/src/bin/std_fs_file_create.rs
@@ -1,4 +1,8 @@
-// { "preopens": { "/scratch": "scratch" } }
+// {
+//     "preopens": {
+//         "/scratch": "scratch"
+//     }
+// }
 
 fn main() {
   assert!(std::fs::File::create("/scratch/file").is_ok());

--- a/src/bin/std_fs_file_metadata.rs
+++ b/src/bin/std_fs_file_metadata.rs
@@ -1,4 +1,8 @@
-// { "preopens": { "/fixture": "fixture" } }
+// {
+//     "preopens": {
+//         "/fixture": "fixture"
+//     }
+// }
 
 fn main() {
   let file = std::fs::File::open("/fixture/file").unwrap();

--- a/src/bin/std_fs_file_seek.rs
+++ b/src/bin/std_fs_file_seek.rs
@@ -1,4 +1,8 @@
-// { "preopens": { "/fixture": "fixture" } }
+// {
+//     "preopens": {
+//         "/fixture": "fixture"
+//     }
+// }
 
 use std::io::Seek;
 

--- a/src/bin/std_fs_file_set_len.rs
+++ b/src/bin/std_fs_file_set_len.rs
@@ -1,4 +1,8 @@
-// { "preopens": { "/scratch": "scratch" } }
+// {
+//     "preopens": {
+//         "/scratch": "scratch"
+//     }
+// }
 
 fn main() {
   let file = std::fs::File::create("/scratch/file").unwrap();

--- a/src/bin/std_fs_file_sync_all.rs
+++ b/src/bin/std_fs_file_sync_all.rs
@@ -1,4 +1,8 @@
-// { "preopens": { "/scratch": "scratch" } }
+// {
+//     "preopens": {
+//         "/scratch": "scratch"
+//     }
+// }
 
 fn main() {
   let file = std::fs::File::create("/scratch/file").unwrap();

--- a/src/bin/std_fs_file_sync_data.rs
+++ b/src/bin/std_fs_file_sync_data.rs
@@ -1,4 +1,8 @@
-// { "preopens": { "/scratch": "scratch" } }
+// {
+//     "preopens": {
+//         "/scratch": "scratch"
+//     }
+// }
 
 use std::io::Write;
 

--- a/src/bin/std_fs_hard_link.rs
+++ b/src/bin/std_fs_hard_link.rs
@@ -1,4 +1,9 @@
-// { "preopens": { "/fixture": "fixture", "/scratch": "scratch" } }
+// {
+//     "preopens": {
+//         "/fixture": "fixture",
+//         "/scratch": "scratch"
+//     }
+// }
 
 fn main() {
   assert!(

--- a/src/bin/std_fs_metadata.rs
+++ b/src/bin/std_fs_metadata.rs
@@ -1,4 +1,8 @@
-// { "preopens": { "/fixture": "fixture" } }
+// {
+//     "preopens": {
+//         "/fixture": "fixture"
+//     }
+// }
 
 fn main() {
   let metadata = std::fs::metadata("/fixture/directory").unwrap();

--- a/src/bin/std_fs_read.rs
+++ b/src/bin/std_fs_read.rs
@@ -1,4 +1,8 @@
-// { "preopens": { "/fixture": "fixture" } }
+// {
+//     "preopens": {
+//         "/fixture": "fixture"
+//     }
+// }
 
 fn main() {
   assert_eq!(std::fs::read("/fixture/file").unwrap(), b"file\n");

--- a/src/bin/std_fs_read_dir.rs
+++ b/src/bin/std_fs_read_dir.rs
@@ -1,4 +1,8 @@
-// { "preopens": { "/fixture": "fixture" } }
+// {
+//     "preopens": {
+//         "/fixture": "fixture"
+//     }
+// }
 
 fn main() {
   let entries = std::fs::read_dir("/fixture").unwrap();

--- a/src/bin/std_fs_rename.rs
+++ b/src/bin/std_fs_rename.rs
@@ -1,4 +1,8 @@
-// { "preopens": { "/scratch": "scratch" } }
+// {
+//     "preopens": {
+//         "/scratch": "scratch"
+//     }
+// }
 
 fn main() {
   let old_path = "/scratch/old_file";

--- a/src/bin/std_fs_symlink_metadata.rs
+++ b/src/bin/std_fs_symlink_metadata.rs
@@ -1,4 +1,8 @@
-// { "preopens": { "/fixture": "fixture" } }
+// {
+//     "preopens": {
+//         "/fixture": "fixture"
+//     }
+// }
 
 fn main() {
   let metadata = std::fs::symlink_metadata("/fixture/directory").unwrap();

--- a/src/bin/std_fs_write.rs
+++ b/src/bin/std_fs_write.rs
@@ -1,4 +1,11 @@
-// { "preopens": { "/scratch": "scratch" }, "files": { "scratch/file": "file" } }
+// {
+//     "preopens": {
+//         "/scratch": "scratch"
+//     },
+//     "files": {
+//         "scratch/file": "file"
+//     }
+// }
 
 fn main() {
   assert!(std::fs::write("/scratch/file", b"file").is_ok())

--- a/src/bin/std_io_stderr.rs
+++ b/src/bin/std_io_stderr.rs
@@ -1,4 +1,6 @@
-// { "stderr": "Hello, stderr!" }
+// {
+//     "stderr": "Hello, stderr!"
+// }
 
 use std::io::Write;
 

--- a/src/bin/std_io_stdin.rs
+++ b/src/bin/std_io_stdin.rs
@@ -1,4 +1,6 @@
-// { "stdin": "Hello, stdin!" }
+// {
+//     "stdin": "Hello, stdin!"
+// }
 
 use std::io::Read;
 

--- a/src/bin/std_io_stdout.rs
+++ b/src/bin/std_io_stdout.rs
@@ -1,4 +1,6 @@
-// { "stdout": "Hello, stdout!" }
+// {
+//     "stdout": "Hello, stdout!"
+// }
 
 use std::io::Write;
 

--- a/src/bin/std_process_exit.rs
+++ b/src/bin/std_process_exit.rs
@@ -1,4 +1,6 @@
-// { "exitCode": 120 }
+// {
+//     "exitCode": 120
+// }
 
 fn main() {
   std::process::exit(120);


### PR DESCRIPTION
This re-formats the json prelude from a single line to a multi-line block delimited by \n\n.