### PR TITLE
Add none variation of std::env::args test.

### DIFF
--- a/src/bin/std_env_args_none.rs
+++ b/src/bin/std_env_args_none.rs
@@ -1,0 +1,10 @@
+// {
+//     "args": [
+//     ]
+// }
+
+fn main() {
+  let mut args = std::env::args();
+  assert_eq!(args.len(), 1);
+  assert!(args.next().unwrap().contains("std_env_args_none.wasm"));
+}

--- a/src/bin/std_env_args_some.rs
+++ b/src/bin/std_env_args_some.rs
@@ -9,7 +9,7 @@
 fn main() {
   let mut args = std::env::args();
   assert_eq!(args.len(), 4);
-  assert!(args.next().unwrap().contains("std_env_args.wasm"));
+  assert!(args.next().unwrap().contains("std_env_args_some.wasm"));
   assert_eq!(args.next().unwrap(), "one");
   assert_eq!(args.next().unwrap(), "two");
   assert_eq!(args.next().unwrap(), "three");


### PR DESCRIPTION
This adds a variation of the std::env::args test where no arguments are provided.