### PR TITLE
Merge scratch directory into fixture directory

### DIFF
--- a/src/bin/std_fs_create_dir_absolute.rs
+++ b/src/bin/std_fs_create_dir_absolute.rs
@@ -1,10 +1,10 @@
 // {
 //     "preopens": {
-//         "/scratch": "scratch"
+//         "/fixture": "fixture"
 //     }
 // }
 
 fn main() {
-  assert!(std::fs::create_dir("/scratch/directory").is_ok());
-  assert!(std::fs::metadata("/scratch/directory").unwrap().is_dir());
+  assert!(std::fs::create_dir("/fixture/new_directory").is_ok());
+  assert!(std::fs::metadata("/fixture/new_directory").unwrap().is_dir());
 }

--- a/src/bin/std_fs_create_dir_relative.rs
+++ b/src/bin/std_fs_create_dir_relative.rs
@@ -1,10 +1,10 @@
 // {
 //     "preopens": {
-//         "scratch": "scratch"
+//         "fixture": "fixture"
 //     }
 // }
 
 fn main() {
-  assert!(std::fs::create_dir("scratch/directory").is_ok());
-  assert!(std::fs::metadata("scratch/directory").unwrap().is_dir());
+  assert!(std::fs::create_dir("fixture/new_directory").is_ok());
+  assert!(std::fs::metadata("fixture/new_directory").unwrap().is_dir());
 }

--- a/src/bin/std_fs_file_create_absolute.rs
+++ b/src/bin/std_fs_file_create_absolute.rs
@@ -1,10 +1,10 @@
 // {
 //     "preopens": {
-//         "/scratch": "scratch"
+//         "/fixture": "fixture"
 //     }
 // }
 
 fn main() {
-  assert!(std::fs::File::create("/scratch/file").is_ok());
-  assert!(std::fs::metadata("/scratch/file").unwrap().is_file());
+  assert!(std::fs::File::create("/fixture/new_file").is_ok());
+  assert!(std::fs::metadata("/fixture/new_file").unwrap().is_file());
 }

--- a/src/bin/std_fs_file_create_relative.rs
+++ b/src/bin/std_fs_file_create_relative.rs
@@ -1,10 +1,10 @@
 // {
 //     "preopens": {
-//         "scratch": "scratch"
+//         "fixture": "fixture"
 //     }
 // }
 
 fn main() {
-  assert!(std::fs::File::create("scratch/file").is_ok());
-  assert!(std::fs::metadata("scratch/file").unwrap().is_file());
+  assert!(std::fs::File::create("fixture/new_file").is_ok());
+  assert!(std::fs::metadata("fixture/new_file").unwrap().is_file());
 }

--- a/src/bin/std_fs_file_set_len_absolute.rs
+++ b/src/bin/std_fs_file_set_len_absolute.rs
@@ -1,11 +1,11 @@
 // {
 //     "preopens": {
-//         "/scratch": "scratch"
+//         "/fixture": "fixture"
 //     }
 // }
 
 fn main() {
-  let file = std::fs::File::create("/scratch/file").unwrap();
+  let file = std::fs::File::create("/fixture/new_file").unwrap();
 
   assert!(file.set_len(0).is_ok());
   assert_eq!(file.metadata().unwrap().len(), 0);

--- a/src/bin/std_fs_file_set_len_relative.rs
+++ b/src/bin/std_fs_file_set_len_relative.rs
@@ -1,11 +1,11 @@
 // {
 //     "preopens": {
-//         "scratch": "scratch"
+//         "fixture": "fixture"
 //     }
 // }
 
 fn main() {
-  let file = std::fs::File::create("scratch/file").unwrap();
+  let file = std::fs::File::create("fixture/new_file").unwrap();
 
   assert!(file.set_len(0).is_ok());
   assert_eq!(file.metadata().unwrap().len(), 0);

--- a/src/bin/std_fs_file_sync_all_absolute.rs
+++ b/src/bin/std_fs_file_sync_all_absolute.rs
@@ -1,19 +1,19 @@
 // {
 //     "preopens": {
-//         "/scratch": "scratch"
+//         "/fixture": "fixture"
 //     }
 // }
 
 fn main() {
-  let file = std::fs::File::create("/scratch/file").unwrap();
+  let file = std::fs::File::create("/fixture/new_file").unwrap();
 
   assert!(file.set_len(5).is_ok());
   assert!(file.sync_all().is_ok());
-  let metadata = std::fs::metadata("/scratch/file").unwrap();
+  let metadata = std::fs::metadata("/fixture/new_file").unwrap();
   assert_eq!(metadata.len(), 5);
 
   assert!(file.set_len(25).is_ok());
   assert!(file.sync_all().is_ok());
-  let metadata = std::fs::metadata("/scratch/file").unwrap();
+  let metadata = std::fs::metadata("/fixture/new_file").unwrap();
   assert_eq!(metadata.len(), 25);
 }

--- a/src/bin/std_fs_file_sync_all_relative.rs
+++ b/src/bin/std_fs_file_sync_all_relative.rs
@@ -1,19 +1,19 @@
 // {
 //     "preopens": {
-//         "scratch": "scratch"
+//         "fixture": "fixture"
 //     }
 // }
 
 fn main() {
-  let file = std::fs::File::create("scratch/file").unwrap();
+  let file = std::fs::File::create("fixture/file").unwrap();
 
   assert!(file.set_len(5).is_ok());
   assert!(file.sync_all().is_ok());
-  let metadata = std::fs::metadata("scratch/file").unwrap();
+  let metadata = std::fs::metadata("fixture/file").unwrap();
   assert_eq!(metadata.len(), 5);
 
   assert!(file.set_len(25).is_ok());
   assert!(file.sync_all().is_ok());
-  let metadata = std::fs::metadata("scratch/file").unwrap();
+  let metadata = std::fs::metadata("fixture/file").unwrap();
   assert_eq!(metadata.len(), 25);
 }

--- a/src/bin/std_fs_file_sync_data_absolute.rs
+++ b/src/bin/std_fs_file_sync_data_absolute.rs
@@ -1,19 +1,19 @@
 // {
 //     "preopens": {
-//         "/scratch": "scratch"
+//         "/fixture": "fixture"
 //     }
 // }
 
 use std::io::Write;
 
 fn main() {
-  let mut file = std::fs::File::create("/scratch/file").unwrap();
+  let mut file = std::fs::File::create("/fixture/new_file").unwrap();
 
   assert!(file.write(b"Hello").is_ok());
   assert!(file.sync_data().is_ok());
-  assert_eq!(std::fs::read("/scratch/file").unwrap(), b"Hello");
+  assert_eq!(std::fs::read("/fixture/new_file").unwrap(), b"Hello");
 
   assert!(file.write(b", world!").is_ok());
   assert!(file.sync_data().is_ok());
-  assert_eq!(std::fs::read("/scratch/file").unwrap(), b"Hello, world!");
+  assert_eq!(std::fs::read("/fixture/new_file").unwrap(), b"Hello, world!");
 }

--- a/src/bin/std_fs_file_sync_data_relative.rs
+++ b/src/bin/std_fs_file_sync_data_relative.rs
@@ -1,19 +1,19 @@
 // {
 //     "preopens": {
-//         "scratch": "scratch"
+//         "fixture": "fixture"
 //     }
 // }
 
 use std::io::Write;
 
 fn main() {
-  let mut file = std::fs::File::create("scratch/file").unwrap();
+  let mut file = std::fs::File::create("fixture/new_file").unwrap();
 
   assert!(file.write(b"Hello").is_ok());
   assert!(file.sync_data().is_ok());
-  assert_eq!(std::fs::read("scratch/file").unwrap(), b"Hello");
+  assert_eq!(std::fs::read("fixture/new_file").unwrap(), b"Hello");
 
   assert!(file.write(b", world!").is_ok());
   assert!(file.sync_data().is_ok());
-  assert_eq!(std::fs::read("scratch/file").unwrap(), b"Hello, world!");
+  assert_eq!(std::fs::read("fixture/new_file").unwrap(), b"Hello, world!");
 }

--- a/src/bin/std_fs_hard_link_absolute.rs
+++ b/src/bin/std_fs_hard_link_absolute.rs
@@ -1,16 +1,15 @@
 // {
 //     "preopens": {
-//         "/fixture": "fixture",
-//         "/scratch": "scratch"
+//         "/fixture": "fixture"
 //     }
 // }
 
 fn main() {
   assert!(
-    std::fs::hard_link("/fixture/file", "/scratch/hardlink_to_file").is_ok()
+    std::fs::hard_link("/fixture/file", "/fixture/hardlink_to_file").is_ok()
   );
   assert_eq!(
     std::fs::read("/fixture/file").unwrap(),
-    std::fs::read("/scratch/hardlink_to_file").unwrap()
+    std::fs::read("/fixture/hardlink_to_file").unwrap()
   );
 }

--- a/src/bin/std_fs_hard_link_relative.rs
+++ b/src/bin/std_fs_hard_link_relative.rs
@@ -1,16 +1,15 @@
 // {
 //     "preopens": {
-//         "fixture": "fixture",
-//         "scratch": "scratch"
+//         "fixture": "fixture"
 //     }
 // }
 
 fn main() {
   assert!(
-    std::fs::hard_link("fixture/file", "scratch/hardlink_to_file").is_ok()
+    std::fs::hard_link("fixture/file", "fixture/hardlink_to_file").is_ok()
   );
   assert_eq!(
     std::fs::read("fixture/file").unwrap(),
-    std::fs::read("scratch/hardlink_to_file").unwrap()
+    std::fs::read("fixture/hardlink_to_file").unwrap()
   );
 }

--- a/src/bin/std_fs_rename_absolute.rs
+++ b/src/bin/std_fs_rename_absolute.rs
@@ -1,12 +1,12 @@
 // {
 //     "preopens": {
-//         "/scratch": "scratch"
+//         "/fixture": "fixture"
 //     }
 // }
 
 fn main() {
-  let old_path = "/scratch/old_file";
-  let new_path = "/scratch/new_file";
+  let old_path = "/fixture/old_file";
+  let new_path = "/fixture/new_file";
 
   assert!(std::fs::write(old_path, b"Hello, world!").is_ok());
   assert!(std::fs::rename(old_path, new_path).is_ok());

--- a/src/bin/std_fs_rename_relative.rs
+++ b/src/bin/std_fs_rename_relative.rs
@@ -1,12 +1,12 @@
 // {
 //     "preopens": {
-//         "scratch": "scratch"
+//         "fixture": "fixture"
 //     }
 // }
 
 fn main() {
-  let old_path = "scratch/old_file";
-  let new_path = "scratch/new_file";
+  let old_path = "fixture/old_file";
+  let new_path = "fixture/new_file";
 
   assert!(std::fs::write(old_path, b"Hello, world!").is_ok());
   assert!(std::fs::rename(old_path, new_path).is_ok());

--- a/src/bin/std_fs_write_absolute.rs
+++ b/src/bin/std_fs_write_absolute.rs
@@ -1,12 +1,12 @@
 // {
 //     "preopens": {
-//         "/scratch": "scratch"
+//         "/fixture": "fixture"
 //     },
 //     "files": {
-//         "scratch/file": "file"
+//         "fixture/new_file": "new_file"
 //     }
 // }
 
 fn main() {
-  assert!(std::fs::write("/scratch/file", b"file").is_ok())
+  assert!(std::fs::write("/fixture/new_file", b"new_file").is_ok())
 }

--- a/src/bin/std_fs_write_relative.rs
+++ b/src/bin/std_fs_write_relative.rs
@@ -1,12 +1,12 @@
 // {
 //     "preopens": {
-//         "scratch": "scratch"
+//         "fixture": "fixture"
 //     },
 //     "files": {
-//         "scratch/file": "file"
+//         "fixture/new_file": "new_file"
 //     }
 // }
 
 fn main() {
-  assert!(std::fs::write("scratch/file", b"file").is_ok())
+  assert!(std::fs::write("fixture/new_file", b"new_file").is_ok())
 }


### PR DESCRIPTION
This merges the scratch directory into the fixture directory, meaning that test runners are expected to set up a clean workspace for each test case copying the fixture directory into the working directory.