### PR TITLE
Add std::fs::remove_dir_all tests

### DIFF
--- a/src/bin/std_fs_remove_dir_all_absolute.rs
+++ b/src/bin/std_fs_remove_dir_all_absolute.rs
@@ -1,0 +1,9 @@
+// {
+//     "preopens": {
+//         "/fixtures": "fixtures"
+//     }
+// }
+
+fn main() {
+    assert!(std::fs::remove_dir_all("/fixtures/directory").is_ok());
+}

--- a/src/bin/std_fs_remove_dir_all_relative.rs
+++ b/src/bin/std_fs_remove_dir_all_relative.rs
@@ -1,0 +1,9 @@
+// {
+//     "preopens": {
+//         "fixtures": "fixtures"
+//     }
+// }
+
+fn main() {
+    assert!(std::fs::remove_dir_all("fixtures/directory").is_ok());
+}


### PR DESCRIPTION
This adds a couple of tests to ensure that std::fs::remove_dir_all can successfully remove directories.