### PR TITLE
Add wasi::fd_fdstat_get tests

### DIFF
--- a/src/bin/wasi_fd_fdstat_get_stderr.rs
+++ b/src/bin/wasi_fd_fdstat_get_stderr.rs
@@ -1,0 +1,10 @@
+// {
+// }
+
+fn main() {
+    unsafe {
+        let fdstat = wasi::fd_fdstat_get(wasi::FD_STDERR).unwrap();
+        assert_eq!(fdstat.fs_filetype, wasi::FILETYPE_CHARACTER_DEVICE);
+        assert!((fdstat.fs_flags & wasi::FDFLAGS_APPEND) != 0);
+    }
+}

--- a/src/bin/wasi_fd_fdstat_get_stdin.rs
+++ b/src/bin/wasi_fd_fdstat_get_stdin.rs
@@ -1,0 +1,10 @@
+// {
+// }
+
+fn main() {
+    unsafe {
+        let fdstat = wasi::fd_fdstat_get(wasi::FD_STDIN).unwrap();
+        assert_eq!(fdstat.fs_filetype, wasi::FILETYPE_CHARACTER_DEVICE);
+        assert!((fdstat.fs_flags & wasi::FDFLAGS_APPEND) != 0);
+    }
+}

--- a/src/bin/wasi_fd_fdstat_get_stdout.rs
+++ b/src/bin/wasi_fd_fdstat_get_stdout.rs
@@ -1,0 +1,10 @@
+// {
+// }
+
+fn main() {
+    unsafe {
+        let fdstat = wasi::fd_fdstat_get(wasi::FD_STDOUT).unwrap();
+        assert_eq!(fdstat.fs_filetype, wasi::FILETYPE_CHARACTER_DEVICE);
+        assert!((fdstat.fs_flags & wasi::FDFLAGS_APPEND) != 0);
+    }
+}


### PR DESCRIPTION
This adds a couple of tests to ensure that wasi::fd_fdstat_get returns the correct type and flags for stdin, stdout and stderr.

Rights to be determined at a later point and are not asserted.