### PR TITLE
Add wasi::fd_tell file test

### DIFF
--- a/src/bin/wasi_fd_tell_file.rs
+++ b/src/bin/wasi_fd_tell_file.rs
@@ -1,0 +1,47 @@
+// {
+//     "preopens": {
+//         "fixtures": "fixtures"
+//     }
+// }
+
+fn main() {
+    unsafe {
+        let dir_fd = 3;
+        let file_fd = wasi::path_open(
+            dir_fd,
+            0,
+            "new_file",
+            wasi::OFLAGS_CREAT,
+            wasi::RIGHTS_FD_WRITE | wasi::RIGHTS_FD_TELL,
+            0,
+            0,
+        ).unwrap();
+
+        let offset = wasi::fd_tell(file_fd).unwrap();
+        assert_eq!(offset, 0);
+
+        let data = b"0";
+        let ciovec = [wasi::Ciovec {
+            buf: data.as_ptr(),
+            buf_len: data.len(),
+        }];
+
+        let nwritten = wasi::fd_write(file_fd, &ciovec).unwrap();
+        assert_eq!(nwritten, 1);
+
+        let offset = wasi::fd_tell(file_fd).unwrap();
+        assert_eq!(offset, 1);
+
+        let nwritten = wasi::fd_write(file_fd, &ciovec).unwrap();
+        assert_eq!(nwritten, 1);
+
+        let offset = wasi::fd_tell(file_fd).unwrap();
+        assert_eq!(offset, 2);
+
+        let nwritten = wasi::fd_write(file_fd, &ciovec).unwrap();
+        assert_eq!(nwritten, 1);
+
+        let offset = wasi::fd_tell(file_fd).unwrap();
+        assert_eq!(offset, 3);
+    }
+}


### PR DESCRIPTION
This adds a test to ensure that wasi::fd_tell returns the correct offset after file writes.