### PR TITLE
Enable LTO on release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ serde_json = "1.0"
 
 [dependencies]
 wasi = "0.10.0+wasi-snapshot-preview1"
+
+[profile.release]
+lto = true


### PR DESCRIPTION
This enables LTO to shave down on the binary size of release builds which can grow quite large considering how small and simple the test programs are.