### PR TITLE
Optimize release builds for size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ wasi = "0.10.0+wasi-snapshot-preview1"
 
 [profile.release]
 lto = true
+opt-level = "z"


### PR DESCRIPTION
This builds release builds with Oz which brings the size down about another 30% from only building with LTO.