### PR TITLE
Add wasi::sched_yield test

### DIFF
--- a/src/bin/wasi_sched_yield.rs
+++ b/src/bin/wasi_sched_yield.rs
@@ -1,0 +1,8 @@
+// {
+// }
+
+fn main() {
+    unsafe {
+        assert!(wasi::sched_yield().is_ok());
+    }
+}


### PR DESCRIPTION
This adds a very basic test to ensure that calls to wasi::sched_yield succeed.