### PR TITLE
Merge wasi::clock_res_get variants into one test

### DIFF
--- a/src/bin/wasi_clock_res_get.rs
+++ b/src/bin/wasi_clock_res_get.rs
@@ -1,0 +1,31 @@
+// {
+// }
+
+unsafe fn test_clock_res_get_monotonic() {
+    let res = wasi::clock_res_get(wasi::CLOCKID_MONOTONIC).unwrap();
+    assert!(res > 0);
+}
+
+unsafe fn test_clock_res_get_realtime() {
+    let res = wasi::clock_res_get(wasi::CLOCKID_REALTIME).unwrap();
+    assert!(res > 0);
+}
+
+unsafe fn test_clock_res_get_process_cputime_id() {
+    let res = wasi::clock_res_get(wasi::CLOCKID_PROCESS_CPUTIME_ID).unwrap();
+    assert!(res > 0);
+}
+
+unsafe fn test_clock_res_get_thread_cputime_id() {
+    let res = wasi::clock_res_get(wasi::CLOCKID_THREAD_CPUTIME_ID).unwrap();
+    assert!(res > 0);
+}
+
+fn main() {
+    unsafe {
+        test_clock_res_get_monotonic();
+        test_clock_res_get_realtime();
+        test_clock_res_get_process_cputime_id();
+        test_clock_res_get_thread_cputime_id();
+    }
+}

--- a/src/bin/wasi_clock_res_get_monotonic.rs
+++ b/src/bin/wasi_clock_res_get_monotonic.rs
@@ -1,9 +1,0 @@
-// {
-// }
-
-fn main() {
-    unsafe {
-        let resolution = wasi::clock_res_get(wasi::CLOCKID_MONOTONIC).unwrap();
-        assert!(resolution > 0);
-    }
-}

--- a/src/bin/wasi_clock_res_get_process.rs
+++ b/src/bin/wasi_clock_res_get_process.rs
@@ -1,9 +1,0 @@
-// {
-// }
-
-fn main() {
-    unsafe {
-        let resolution = wasi::clock_res_get(wasi::CLOCKID_PROCESS_CPUTIME_ID).unwrap();
-        assert!(resolution > 0);
-    }
-}

--- a/src/bin/wasi_clock_res_get_realtime.rs
+++ b/src/bin/wasi_clock_res_get_realtime.rs
@@ -1,9 +1,0 @@
-// {
-// }
-
-fn main() {
-    unsafe {
-        let resolution = wasi::clock_res_get(wasi::CLOCKID_REALTIME).unwrap();
-        assert!(resolution > 0);
-    }
-}

--- a/src/bin/wasi_clock_res_get_thread.rs
+++ b/src/bin/wasi_clock_res_get_thread.rs
@@ -1,9 +1,0 @@
-// {
-// }
-
-fn main() {
-    unsafe {
-        let resolution = wasi::clock_res_get(wasi::CLOCKID_THREAD_CPUTIME_ID).unwrap();
-        assert!(resolution > 0);
-    }
-}


### PR DESCRIPTION
This merges the wasi::clock_res_get tests into one test module as they all share the same inputs therefore do not require specialization.