### PR TITLE
Fix the first expected std::env::args value

### DIFF
--- a/src/bin/std_env_args.rs
+++ b/src/bin/std_env_args.rs
@@ -9,7 +9,7 @@
 fn main() {
   let mut args = std::env::args();
   assert_eq!(args.len(), 4);
-  assert!(args.next().unwrap().contains("std_env_args_some.wasm"));
+  assert!(args.next().unwrap().contains("std_env_args.wasm"));
   assert_eq!(args.next().unwrap(), "one");
   assert_eq!(args.next().unwrap(), "two");
   assert_eq!(args.next().unwrap(), "three");


### PR DESCRIPTION
Forgot to rename the expected value of std::env::args.first() to remove the "some" suffix in 40b334d4eb536c337584dd3b8c1683b27ba0d623.

This fixes that to match the current name of the expected executable.