### PR TITLE
Add wasi::path_open tests

### DIFF
--- a/src/bin/wasi_path_open.rs
+++ b/src/bin/wasi_path_open.rs
@@ -1,0 +1,42 @@
+// {
+//     "preopens": {
+//         "fixtures": "fixtures"
+//     }
+// }
+
+unsafe fn test_wasi_path_open_parent_directory() {
+    let dir_fd = 3;
+    let err = wasi::path_open(
+        dir_fd,
+        0,
+        "..",
+        wasi::OFLAGS_CREAT,
+        wasi::RIGHTS_FD_WRITE | wasi::RIGHTS_FD_TELL,
+        0,
+        0,
+    ).unwrap_err();
+
+    assert_eq!(err.raw_error(), wasi::ERRNO_NOTCAPABLE);
+}
+
+unsafe fn test_wasi_path_open_symlink_to_parent_directory() {
+    let dir_fd = 3;
+    let err = wasi::path_open(
+        dir_fd,
+        0,
+        "symlink_to_parent_directory",
+        wasi::OFLAGS_CREAT,
+        wasi::RIGHTS_FD_WRITE | wasi::RIGHTS_FD_TELL,
+        0,
+        0,
+    ).unwrap_err();
+
+    assert_eq!(err.raw_error(), wasi::ERRNO_NOTCAPABLE);
+}
+
+fn main() {
+    unsafe {
+        test_wasi_path_open_parent_directory();
+        test_wasi_path_open_symlink_to_parent_directory();
+    }
+}


### PR DESCRIPTION
This adds a couple of interesting path tests to ensure that wasi::path_open does not allow opening files outside the pre-opened directory.