### PR TITLE
Annotate wasi::proc_exit unreachable

### DIFF
--- a/src/bin/wasi_proc_exit.rs
+++ b/src/bin/wasi_proc_exit.rs
@@ -4,7 +4,7 @@
 
 unsafe fn test_proc_exit_one() {
     wasi::proc_exit(1);
-    unreachable!();
+    unreachable!("proc_exit");
 }
 
 fn main() {


### PR DESCRIPTION
This adds a minor annotation to the unreachable after wasi::proc_exit to be be able to distinguish it from unreachable errors that may happen during pre-open handling.