### PR TITLE
Remove stray symlink fixture

### DIFF
--- a/symlink_to_parent_directory
+++ b/symlink_to_parent_directory
@@ -1,1 +1,0 @@
-fixtures/symlink_to_parent_directory


### PR DESCRIPTION
A stray symlink fixture made its way into the root directory by accident.

This removes the offending symlink.