### PR TITLE
Add path open test for directory/../..

### DIFF
--- a/src/bin/wasi_path_open.rs
+++ b/src/bin/wasi_path_open.rs
@@ -19,6 +19,21 @@ unsafe fn test_wasi_path_open_parent_directory() {
     assert_eq!(err.raw_error(), wasi::ERRNO_NOTCAPABLE);
 }
 
+unsafe fn test_wasi_path_open_directory_parent_directory_parent_directory() {
+    let dir_fd = 3;
+    let err = wasi::path_open(
+        dir_fd,
+        0,
+        "directory/../..",
+        wasi::OFLAGS_DIRECTORY,
+        0,
+        0,
+        0,
+    ).unwrap_err();
+
+    assert_eq!(err.raw_error(), wasi::ERRNO_NOTCAPABLE);
+}
+
 unsafe fn test_wasi_path_open_symlink_to_parent_directory() {
     let dir_fd = 3;
     let err = wasi::path_open(
@@ -37,6 +52,7 @@ unsafe fn test_wasi_path_open_symlink_to_parent_directory() {
 fn main() {
     unsafe {
         test_wasi_path_open_parent_directory();
+        test_wasi_path_open_directory_parent_directory_parent_directory();
         test_wasi_path_open_symlink_to_parent_directory();
     }
 }


### PR DESCRIPTION
This adds a test case to ensure that we can't escape from a directory using to levels of "dot-dot" (e.g directory/../..).