### PR TITLE
Fix the deno compatability runner

### DIFF
--- a/compat.py
+++ b/compat.py
@@ -54,8 +54,7 @@ def test_deno(filepath, config, cwd):
           WebAssembly.instantiate(buffer, {
             wasi_snapshot_preview1: wasi.exports,
           }).then(function({ instance }) {
-              wasi.memory = instance.exports.memory;
-              instance.exports._start();
+            wasi.start(instance);
           });
         '''))
 


### PR DESCRIPTION
The API changed in 1.6 and Deno now has a start entry point on the WebAssembly context.