### PR TITLE
Remove the process and thread clock tests.

### DIFF
--- a/src/bin/wasi_clock_res_get.rs
+++ b/src/bin/wasi_clock_res_get.rs
@@ -11,21 +11,9 @@ unsafe fn test_clock_res_get_realtime() {
     assert!(res > 0);
 }
 
-unsafe fn test_clock_res_get_process_cputime_id() {
-    let res = wasi::clock_res_get(wasi::CLOCKID_PROCESS_CPUTIME_ID).unwrap();
-    assert!(res > 0);
-}
-
-unsafe fn test_clock_res_get_thread_cputime_id() {
-    let res = wasi::clock_res_get(wasi::CLOCKID_THREAD_CPUTIME_ID).unwrap();
-    assert!(res > 0);
-}
-
 fn main() {
     unsafe {
         test_clock_res_get_monotonic();
         test_clock_res_get_realtime();
-        test_clock_res_get_process_cputime_id();
-        test_clock_res_get_thread_cputime_id();
     }
 }

--- a/src/bin/wasi_clock_time_get.rs
+++ b/src/bin/wasi_clock_time_get.rs
@@ -35,46 +35,9 @@ unsafe fn test_clock_time_get_realtime() {
     assert!(time2 > time1);
 }
 
-unsafe fn test_clock_time_get_process_cputime_id() {
-    let time1 = wasi::clock_time_get(wasi::CLOCKID_PROCESS_CPUTIME_ID, 0).unwrap();
-    assert!(time1 > 0);
-
-    for _ in 0..100000 {
-        let time2 = wasi::clock_time_get(wasi::CLOCKID_PROCESS_CPUTIME_ID, 1).unwrap();
-        assert!(time2 >= time1);
-
-        if time2 > time1 {
-            break;
-        }
-    }
-
-    let time2 = wasi::clock_time_get(wasi::CLOCKID_PROCESS_CPUTIME_ID, 1).unwrap();
-    assert!(time2 > time1);
-}
-
-unsafe fn test_clock_time_get_thread_cputime_id() {
-    let time1 = wasi::clock_time_get(wasi::CLOCKID_THREAD_CPUTIME_ID, 0).unwrap();
-    assert!(time1 > 0);
-
-    for _ in 0..100000 {
-        let time2 = wasi::clock_time_get(wasi::CLOCKID_THREAD_CPUTIME_ID, 1).unwrap();
-        assert!(time2 >= time1);
-
-        if time2 > time1 {
-            break;
-        }
-    }
-
-
-    let time2 = wasi::clock_time_get(wasi::CLOCKID_THREAD_CPUTIME_ID, 1).unwrap();
-    assert!(time2 > time1);
-}
-
 fn main() {
     unsafe {
         test_clock_time_get_monotonic();
         test_clock_time_get_realtime();
-        test_clock_time_get_process_cputime_id();
-        test_clock_time_get_thread_cputime_id();
     }
 }


### PR DESCRIPTION
Remove the tests for `CLOCKID_PROCESS_CPUTIME_ID` and
`CLOCKID_THREAD_CPUTIME_ID`, since these values were
[removed from the WASI spec].

[removed from the WASI spec]: https://github.com/WebAssembly/WASI/pull/197