### PR TITLE
Refine the stdin/stdout/stderr fd_fdstat_get tests.

### DIFF
--- a/src/bin/wasi_fd_fdstat_get.rs
+++ b/src/bin/wasi_fd_fdstat_get.rs
@@ -3,20 +3,62 @@
 
 unsafe fn test_fd_fdstat_get_stdin() {
     let fdstat = wasi::fd_fdstat_get(wasi::FD_STDIN).unwrap();
-    assert_eq!(fdstat.fs_filetype, wasi::FILETYPE_CHARACTER_DEVICE);
-    assert!((fdstat.fs_flags & wasi::FDFLAGS_APPEND) != 0);
+
+    assert_ne!(fdstat.fs_filetype, wasi::FILETYPE_BLOCK_DEVICE);
+    assert_ne!(fdstat.fs_filetype, wasi::FILETYPE_DIRECTORY);
+    assert_ne!(fdstat.fs_filetype, wasi::FILETYPE_SOCKET_DGRAM);
+    assert_ne!(fdstat.fs_filetype, wasi::FILETYPE_SYMBOLIC_LINK);
+
+    assert!((fdstat.fs_flags & wasi::FDFLAGS_NONBLOCK) == 0);
+
+    assert_eq!(
+        (fdstat.fs_rights_base & wasi::RIGHTS_FD_READ),
+        wasi::RIGHTS_FD_READ
+    );
+    assert_eq!(
+        (fdstat.fs_rights_base & wasi::RIGHTS_POLL_FD_READWRITE),
+        wasi::RIGHTS_POLL_FD_READWRITE
+    );
 }
 
 unsafe fn test_fd_fdstat_get_stdout() {
     let fdstat = wasi::fd_fdstat_get(wasi::FD_STDOUT).unwrap();
-    assert_eq!(fdstat.fs_filetype, wasi::FILETYPE_CHARACTER_DEVICE);
-    assert!((fdstat.fs_flags & wasi::FDFLAGS_APPEND) != 0);
+
+    assert_ne!(fdstat.fs_filetype, wasi::FILETYPE_BLOCK_DEVICE);
+    assert_ne!(fdstat.fs_filetype, wasi::FILETYPE_DIRECTORY);
+    assert_ne!(fdstat.fs_filetype, wasi::FILETYPE_SOCKET_DGRAM);
+    assert_ne!(fdstat.fs_filetype, wasi::FILETYPE_SYMBOLIC_LINK);
+
+    assert!((fdstat.fs_flags & wasi::FDFLAGS_NONBLOCK) == 0);
+
+    assert_eq!(
+        (fdstat.fs_rights_base & wasi::RIGHTS_FD_WRITE),
+        wasi::RIGHTS_FD_WRITE
+    );
+    assert_eq!(
+        (fdstat.fs_rights_base & wasi::RIGHTS_POLL_FD_READWRITE),
+        wasi::RIGHTS_POLL_FD_READWRITE
+    );
 }
 
 unsafe fn test_fd_fdstat_get_stderr() {
     let fdstat = wasi::fd_fdstat_get(wasi::FD_STDERR).unwrap();
-    assert_eq!(fdstat.fs_filetype, wasi::FILETYPE_CHARACTER_DEVICE);
-    assert!((fdstat.fs_flags & wasi::FDFLAGS_APPEND) != 0);
+
+    assert_ne!(fdstat.fs_filetype, wasi::FILETYPE_BLOCK_DEVICE);
+    assert_ne!(fdstat.fs_filetype, wasi::FILETYPE_DIRECTORY);
+    assert_ne!(fdstat.fs_filetype, wasi::FILETYPE_SOCKET_DGRAM);
+    assert_ne!(fdstat.fs_filetype, wasi::FILETYPE_SYMBOLIC_LINK);
+
+    assert!((fdstat.fs_flags & wasi::FDFLAGS_NONBLOCK) == 0);
+
+    assert_eq!(
+        (fdstat.fs_rights_base & wasi::RIGHTS_FD_WRITE),
+        wasi::RIGHTS_FD_WRITE
+    );
+    assert_eq!(
+        (fdstat.fs_rights_base & wasi::RIGHTS_POLL_FD_READWRITE),
+        wasi::RIGHTS_POLL_FD_READWRITE
+    );
 }
 
 fn main() {


### PR DESCRIPTION
Don't require stdin/stdout/stderr to be character devices with
`O_APPEND` set. Even in POSIX, these may be redirected from other
kinds of devices and won't always use O_APPEND.

Do check that stdin/stdout/stderr are not any non-readable file
type, that they don't start with O_NONBLOCK set, and that they do
have the expected rights.